### PR TITLE
Add Logger type alias for backward compatibility

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -204,9 +204,9 @@ If you're migrating from the old logging system, here are the key changes:
 ### Old Code
 
 ```python
-from src.core.logging import get_logger
+from src.core.logging import get_logger, Logger
 
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 logger.info("Starting process...")
 logger.debug("Debug info")
 ```
@@ -215,9 +215,10 @@ logger.debug("Debug info")
 
 ```python
 # Using compatibility function (recommended for existing code)
-from src.core.logging import get_logger
+from src.core.logging import get_logger, Logger
 
-logger = get_logger(__name__)  # Returns UnifiedLogger with old interface
+# Logger type alias points to UnifiedLogger for type hints
+logger: Logger = get_logger(__name__)
 logger.info("Starting process...")
 logger.debug("Debug info")
 


### PR DESCRIPTION
This PR adds backward compatibility for code that imports `Logger` from the logging module:

### Changes

- Add `Logger` type alias that points to `UnifiedLogger`
- Update exports in `__init__.py` to include both `Logger` and `get_logger`
- Update documentation with `Logger` type hints
- Fix import error in `optimizations.py`

### Migration Guide

Old code:
```python
from src.core.logging import get_logger, Logger

logger: Logger = get_logger(__name__)
logger.info("Starting process...")
```

New code (compatibility):
```python
from src.core.logging import get_logger, Logger

# Logger type alias points to UnifiedLogger
logger: Logger = get_logger(__name__)
logger.info("Starting process...")

# New features are available
logger.start_progress(total=100)
logger.log_metrics({"loss": 0.5})
```

This change maintains backward compatibility while allowing users to gradually migrate to the new features.